### PR TITLE
 [BE] feat: AnalysisController 구현 및 안쓰는 DTO 제거 + 서비스 개인 분석 조회 생성 분리

### DIFF
--- a/backend/src/main/java/com/devmatch/backend/domain/analysis/controller/AnalysisController.java
+++ b/backend/src/main/java/com/devmatch/backend/domain/analysis/controller/AnalysisController.java
@@ -1,8 +1,58 @@
 package com.devmatch.backend.domain.analysis.controller;
 
+import com.devmatch.backend.domain.analysis.dto.AnalysisResultResponse;
+import com.devmatch.backend.domain.analysis.service.AnalysisService;
+import com.devmatch.backend.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/analysis")
+@RestController
+@RequestMapping("/analysis")
+@RequiredArgsConstructor
 public class AnalysisController {
 
+  private final AnalysisService analysisService;
+
+  @GetMapping("/application/{applicationId}")
+  public ResponseEntity<ApiResponse<AnalysisResultResponse>> getAnalysisResult(
+      @PathVariable Long applicationId
+  ) {
+    AnalysisResultResponse analysisResultResponse = new AnalysisResultResponse(
+        analysisService.getAnalysisResult(applicationId)
+    );
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(new ApiResponse<>("조회 성공", analysisResultResponse));
+  }
+
+  @PostMapping("/application/{applicationId}")
+  public ResponseEntity<ApiResponse<AnalysisResultResponse>> createAnalysisResult(
+      @PathVariable Long applicationId
+  ) {
+    AnalysisResultResponse analysisResultResponse = new AnalysisResultResponse(
+        analysisService.createAnalysisResult(applicationId)
+    );
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(new ApiResponse<>("분석 결과 생성 성공", analysisResultResponse));
+  }
+
+  @PostMapping("/project/{projectId}/role-assignment")
+  public ResponseEntity<ApiResponse<String>> createTeamRoleAssignment(
+      @PathVariable Long projectId
+  ) {
+    String roleAssignment = analysisService.createTeamRoleAssignment(projectId);
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(new ApiResponse<>("팀 역할 분배 완료", roleAssignment));
+  }
 }

--- a/backend/src/main/java/com/devmatch/backend/domain/analysis/dto/AnalysisResultResponse.java
+++ b/backend/src/main/java/com/devmatch/backend/domain/analysis/dto/AnalysisResultResponse.java
@@ -1,4 +1,20 @@
 package com.devmatch.backend.domain.analysis.dto;
 
-public class AnalysisResultResponse {
+import com.devmatch.backend.domain.analysis.entity.AnalysisResult;
+
+public record AnalysisResultResponse(
+    Long id,
+    Long applicationId,
+    double compatibilityScore,
+    String compatibilityReason
+) {
+
+  public AnalysisResultResponse(AnalysisResult result) {
+    this(
+        result.getId(),
+        result.getApplication().getId(),
+        result.getCompatibilityScore(),
+        result.getCompatibilityReason()
+    );
+  }
 }

--- a/backend/src/main/java/com/devmatch/backend/domain/analysis/dto/CompatibilityAnalysisRequest.java
+++ b/backend/src/main/java/com/devmatch/backend/domain/analysis/dto/CompatibilityAnalysisRequest.java
@@ -1,4 +1,0 @@
-package com.devmatch.backend.domain.analysis.dto;
-
-public class CompatibilityAnalysisRequest {
-}

--- a/backend/src/main/java/com/devmatch/backend/domain/analysis/dto/RoleAssignmentRequest.java
+++ b/backend/src/main/java/com/devmatch/backend/domain/analysis/dto/RoleAssignmentRequest.java
@@ -1,4 +1,0 @@
-package com.devmatch.backend.domain.analysis.dto;
-
-public class RoleAssignmentRequest {
-}


### PR DESCRIPTION
  - AnalysisService 메서드 분리
    - getOrAnalyzeCompatibility() → getAnalysisResult(), createAnalysisResult()로 분리
    - 조회와 생성 로직을 명확히 구분
    - assignTeamRoles() → createTeamRoleAssignment()으로 리네이밍

  - AnalysisController 3개 API 구현
    - GET /analysis/application/{applicationId} - 개인 적합도 조회
    - POST /analysis/application/{applicationId} - 개인 적합도 생성
    - POST /analysis/project/{projectId}/role-assignment - 팀 역할 배정

  - DTO 정리
    - 사용하지 않는 Request DTO 제거 (PathVariable만 사용하는 구조)

<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
