### PR TITLE
[BE] fix: 지원서 삭제 로직 수정

### DIFF
--- a/backend/src/main/java/com/devmatch/backend/domain/application/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/devmatch/backend/domain/application/repository/ApplicationRepository.java
@@ -2,13 +2,13 @@ package com.devmatch.backend.domain.application.repository;
 
 import com.devmatch.backend.domain.application.entity.Application;
 import com.devmatch.backend.domain.application.enums.ApplicationStatus;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
-  Optional<Application> findApplicationByUserId(Long id);
+  List<Application> findAllByUserId(Long id);
 
-  Optional<Application> findByProjectAndStatus(Long projectId, ApplicationStatus status);
+  List<Application> findByProjectAndStatus(Long projectId, ApplicationStatus status);
 
 }

--- a/backend/src/main/java/com/devmatch/backend/domain/application/service/ApplicationService.java
+++ b/backend/src/main/java/com/devmatch/backend/domain/application/service/ApplicationService.java
@@ -3,7 +3,7 @@ package com.devmatch.backend.domain.application.service;
 import com.devmatch.backend.domain.application.dto.response.ApplicationDetailResponseDto;
 import com.devmatch.backend.domain.application.entity.Application;
 import com.devmatch.backend.domain.application.repository.ApplicationRepository;
-import com.devmatch.backend.domain.user.repository.UserRepository;
+import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ApplicationService {
 
   private final ApplicationRepository applicationRepository;
-  private final UserRepository userRepository;
 
   // 지원서 상세 조회 로직
   @Transactional(readOnly = true)
@@ -39,9 +38,8 @@ public class ApplicationService {
         .orElseThrow(() -> new NoSuchElementException("지원서를 찾을 수 없습니다. ID: " + id));
   }
 
-  // 사용자 ID로 지원서를 가져오는 함수
-  private Application getApplicationByUserId(Long id) {
-    return applicationRepository.findApplicationByUserId(id)
-        .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다. ID: " + id));
+  // 사용자 ID로 사용자가 작성한 모든 지원서들을 가져오는 함수
+  private List<Application> getApplicationsByUserId(Long id) {
+    return applicationRepository.findAllByUserId(id);
   }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
지원서 삭제 로직 수정
지원서와 사용자의 양방향 연관관계를 해제 해야함.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- [X] 기존에 Application DB에서 직접 삭제하는 applicationRepository.delete(application); 코드 제거
- [X] orphanRemoval = true 를 이용하여 컬렉션에서 제거하는 application.getUser().removeApplication(application); 코드 추가

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
양방향 연관관계 해제를 위해 
`application.getUser().removeApplication(application);`
사용했습니다.

deleteApplication() -> removeApplication() 함수명 변경은 AI 답변으로는

DB에서 삭제하는 서비스 로직에서는 delete가 표준입니다.
remove는 컬렉션 조작이나 soft delete와는 별개 동작 시 내부적으로 사용 가능하지만, DB 삭제와는 거리가 있습니다.

라고 해서 우선 그대로 두었습니다. 혹시나 변경 필요하시면 다시 수정하겠습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
