### PR TITLE
프론트엔드: Vercel 배포를 위한 API URL 수정

### DIFF
--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -15,7 +15,7 @@ import axios, { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 
  * 🔧 설정: 기본 URL, 타임아웃, 쿠키 포함
  */
 export const apiClient: AxiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080', // 🏠 로컬 개발 서버
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'https://nbe-6-8-2-team08.vercel.app/api', // 🌐 Vercel 배포 서버
   timeout: 10000, // ⏱️ 10초 타임아웃
   withCredentials: true, // 🍪 쿠키 포함 (인증을 위해 필수)
 });


### PR DESCRIPTION
## 변경 내용
- 기본 API URL을 localhost:8080에서 배포된 서버 주소로 변경
- 프로덕션 환경에서 백엔드 연결 가능하도록 설정
- NEXT_PUBLIC_API_BASE_URL 환경변수 활용

## 테스트
- Vercel 배포 테스트 완료
- API 연결 설정 확인

## 관련 이슈
- Vercel 배포 시 404 오류 해결
- 프로덕션 환경 API 연결 설정