### PR TITLE
[FE] fix: 프로덕션 환경 API URL 수정 (#153)

### DIFF
--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -15,7 +15,7 @@ import axios, { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 
  * 🔧 설정: 기본 URL, 타임아웃, 쿠키 포함
  */
 export const apiClient: AxiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'https://nbe-6-8-2-team08.vercel.app/api', // 🌐 Vercel 배포 서버
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'https://devmatch-production-cf16.up.railway.app', // 🌐 Railway 백엔드 서버
   timeout: 10000, // ⏱️ 10초 타임아웃
   withCredentials: true, // 🍪 쿠키 포함 (인증을 위해 필수)
 });


### PR DESCRIPTION
## 📋 작업 내용

### 🐛 문제
- 프론트엔드에서 백엔드 API 호출 시 'Failed to fetch' 오류 발생
- API 기본 URL이 잘못된 주소()를 참조

### ✅ 해결
- API 클라이언트의 기본 URL을 Railway 백엔드 서버로 수정
  - 변경 전: 
  - 변경 후: 

### 📝 변경사항
- : baseURL 수정

### 🔧 추가 작업 필요
- Vercel 대시보드에서 환경변수 설정 필요:
  

## 🧪 테스트
- [ ] 로컬 환경에서 백엔드 API 연결 확인
- [ ] 배포 후 프로덕션 환경에서 API 호출 정상 작동 확인