### PR TITLE
[FE] fix: ApplicationAnalysisModal API URL 하드코딩 제거 (#154)

### DIFF
--- a/frontend/src/components/ui/ApplicationAnalysisModal.tsx
+++ b/frontend/src/components/ui/ApplicationAnalysisModal.tsx
@@ -34,7 +34,8 @@ export function ApplicationAnalysisModal({
       
       // AI 분석 결과 조회 - 실제 백엔드 API 호출
       try {
-        const response = await fetch(`http://localhost:8080/analysis/application/${applicationId}`, {
+        const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://devmatch-production-cf16.up.railway.app';
+        const response = await fetch(`${apiUrl}/analysis/application/${applicationId}`, {
           method: 'GET',
           credentials: 'include',
           headers: {
@@ -64,7 +65,7 @@ export function ApplicationAnalysisModal({
         
         // 분석 결과가 없으면 생성 시도
         try {
-          const createResponse = await fetch(`http://localhost:8080/analysis/application/${applicationId}`, {
+          const createResponse = await fetch(`${apiUrl}/analysis/application/${applicationId}`, {
             method: 'POST',
             credentials: 'include',
             headers: {


### PR DESCRIPTION
## 🐛 문제
- ApplicationAnalysisModal 컴포넌트에서 API URL이 \으로 하드코딩됨
- 프로덕션 환경에서 백엔드 API 호출 시 'Failed to fetch' 오류 발생

## ✅ 해결
- API URL을 환경변수 기반으로 변경
- 하드코딩된 URL 제거하고 동적으로 설정

## 📝 변경사항
\http://localhost:8080/analysis/application/\\/analysis/application/\
## 🚀 영향
- 프로덕션 환경에서 AI 분석 기능 정상 작동
- 환경변수를 통한 유연한 API URL 관리