### PR TITLE
[FE] fix: 모달 닫기 방지 기능 구현 및 API URL 하드코딩 수정

### DIFF
--- a/frontend/src/components/ui/ApplicationAnalysisModal.tsx
+++ b/frontend/src/components/ui/ApplicationAnalysisModal.tsx
@@ -125,7 +125,7 @@ export function ApplicationAnalysisModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={loading ? undefined : onClose}>
       <DialogContent className="max-w-7xl max-h-[95vh] overflow-y-auto overflow-x-hidden bg-white border border-gray-300 shadow-xl">
         <DialogHeader className="pb-4 border-b">
           <DialogTitle className="text-xl font-bold">지원서 AI 분석 결과</DialogTitle>

--- a/frontend/src/components/ui/ApplicationAnalysisModal.tsx
+++ b/frontend/src/components/ui/ApplicationAnalysisModal.tsx
@@ -34,7 +34,8 @@ export function ApplicationAnalysisModal({
       
       // AI 분석 결과 조회 - 실제 백엔드 API 호출
       try {
-        const response = await fetch(`http://localhost:8080/analysis/application/${applicationId}`, {
+        const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://devmatch-production-cf16.up.railway.app';
+        const response = await fetch(`${apiUrl}/analysis/application/${applicationId}`, {
           method: 'GET',
           credentials: 'include',
           headers: {
@@ -64,7 +65,7 @@ export function ApplicationAnalysisModal({
         
         // 분석 결과가 없으면 생성 시도
         try {
-          const createResponse = await fetch(`http://localhost:8080/analysis/application/${applicationId}`, {
+          const createResponse = await fetch(`${apiUrl}/analysis/application/${applicationId}`, {
             method: 'POST',
             credentials: 'include',
             headers: {

--- a/frontend/src/components/ui/ApplicationAnalysisModal.tsx
+++ b/frontend/src/components/ui/ApplicationAnalysisModal.tsx
@@ -32,9 +32,10 @@ export function ApplicationAnalysisModal({
       setLoading(true);
       setError(null);
       
+      const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://devmatch-production-cf16.up.railway.app';
+      
       // AI 분석 결과 조회 - 실제 백엔드 API 호출
       try {
-        const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://devmatch-production-cf16.up.railway.app';
         const response = await fetch(`${apiUrl}/analysis/application/${applicationId}`, {
           method: 'GET',
           credentials: 'include',

--- a/frontend/src/components/ui/ProjectApplyModal.tsx
+++ b/frontend/src/components/ui/ProjectApplyModal.tsx
@@ -86,7 +86,7 @@ export function ProjectApplyModal({ project, onApply, isApplying, children }: Pr
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={isApplying ? undefined : setOpen}>
       <DialogTrigger asChild>
         {children}
       </DialogTrigger>


### PR DESCRIPTION
## 📋 작업 내용

### 1. API URL 하드코딩 문제 해결
- ApplicationAnalysisModal의 하드코딩된 localhost:8080 URL을 환경변수 기반으로 변경
- apiUrl 변수 스코프 문제 수정

### 2. 모달 닫기 방지 기능 구현
- **ApplicationAnalysisModal**: AI 분석 중 모달 닫기 비활성화
- **ProjectApplyModal**: 지원서 제출 중 모달 닫기 비활성화
- Dialog의 onOpenChange prop에 조건부 처리 적용

### 3. 기술 스택 검증 확인
- 기존 정규식 \이 이미 특수문자(+, -, #, ., 공백) 허용
- C++, C#, .NET 등 입력 가능 확인

## 🐛 해결된 문제
- Production 환경에서 'Failed to fetch' 에러 수정
- 분석/지원 중 X 버튼 클릭 시 중복 지원서 생성 버그 수정
- 사용자가 실수로 모달을 닫아 데이터 손실되는 문제 방지

## ✅ 테스트
- [x] 로컬 환경에서 모달 닫기 방지 동작 확인
- [x] Production API 호출 정상 동작 확인
- [x] 기술 스택 특수문자 입력 확인