### PR TITLE
[FE] fix: 로딩 중 모달 닫기 방지 기능 구현

### DIFF
--- a/frontend/src/components/ui/ApplicationAnalysisModal.tsx
+++ b/frontend/src/components/ui/ApplicationAnalysisModal.tsx
@@ -124,7 +124,7 @@ export function ApplicationAnalysisModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={loading ? undefined : onClose}>
       <DialogContent className="max-w-7xl max-h-[95vh] overflow-y-auto overflow-x-hidden bg-white border border-gray-300 shadow-xl">
         <DialogHeader className="pb-4 border-b">
           <DialogTitle className="text-xl font-bold">지원서 AI 분석 결과</DialogTitle>

--- a/frontend/src/components/ui/ProjectApplyModal.tsx
+++ b/frontend/src/components/ui/ProjectApplyModal.tsx
@@ -86,7 +86,7 @@ export function ProjectApplyModal({ project, onApply, isApplying, children }: Pr
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={isApplying ? undefined : setOpen}>
       <DialogTrigger asChild>
         {children}
       </DialogTrigger>


### PR DESCRIPTION
## 📋 작업 내용

로딩 중 모달이 닫히지 않도록 방지하는 기능을 구현했습니다.

## 🐛 해결된 문제

1. **중복 지원서 생성 버그**
   - AI 분석 중 X 버튼을 클릭하면 지원서가 중복 생성되는 문제
   - 사용자가 '지원하기' 버튼 클릭 후 분석 중에 모달을 닫으면 발생

2. **데이터 손실 문제**
   - 지원서 제출 중 실수로 모달을 닫아 프로세스가 중단되는 문제

## ✨ 변경사항

### ApplicationAnalysisModal
- AI 분석 로딩 중 모달 닫기 비활성화
- \ 상태일 때 Dialog 닫기 동작 무시

### ProjectApplyModal  
- 지원서 제출 중 모달 닫기 비활성화
- \ 상태일 때 Dialog 닫기 동작 무시

## 🔧 기술적 세부사항

Dialog 컴포넌트의 \ prop에 조건부 처리를 적용했습니다:
- 로딩 중: \ 전달 → 닫기 동작 무시
- 로딩 완료: 기존 핸들러 전달 → 정상 동작

## ✅ 테스트
- [x] AI 분석 중 X 버튼 클릭 시 모달이 닫히지 않음
- [x] 지원서 제출 중 모달 바깥 클릭이나 ESC 키 동작하지 않음
- [x] 로딩 완료 후 정상적으로 모달 닫기 가능