### PR TITLE
[FE] feat: API URL을 api.devmatch.store로 변경

### DIFF
--- a/frontend/src/components/ui/ApplicationAnalysisModal.tsx
+++ b/frontend/src/components/ui/ApplicationAnalysisModal.tsx
@@ -28,7 +28,7 @@ export function ApplicationAnalysisModal({
   const [error, setError] = useState<string | null>(null);
 
   const fetchAnalysisData = useCallback(async () => {
-    const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://devmatch-production-cf16.up.railway.app';
+    const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.devmatch.store';
     
     try {
       setLoading(true);

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -15,7 +15,7 @@ import axios, { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 
  * 🔧 설정: 기본 URL, 타임아웃, 쿠키 포함
  */
 export const apiClient: AxiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'https://devmatch-production-cf16.up.railway.app', // 🌐 Railway 백엔드 서버
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.devmatch.store', // 🌐 백엔드 서버
   timeout: 10000, // ⏱️ 10초 타임아웃
   withCredentials: true, // 🍪 쿠키 포함 (인증을 위해 필수)
 });


### PR DESCRIPTION
## 📝 변경사항

프론트엔드 API URL을 Railway URL에서 자체 도메인으로 변경했습니다.

### 변경된 URL
- 기존: `https://devmatch-production-cf16.up.railway.app`
- 변경: `https://api.devmatch.store`

### 수정된 파일
- `frontend/src/lib/api/index.ts`: API 클라이언트 기본 URL 변경
- `frontend/src/components/ui/ApplicationAnalysisModal.tsx`: 하드코딩된 URL 변경

### ⚠️ 추가 작업 필요
- Vercel 환경변수 `NEXT_PUBLIC_API_BASE_URL`을 `https://api.devmatch.store`로 업데이트 필요
- `.env.production` 파일은 gitignore에 포함되어 있어 별도 배포 시 수정 필요

## ✅ 체크리스트
- [x] 코드 변경사항 확인
- [x] 로컬 테스트 완료
- [ ] Vercel 환경변수 업데이트 (배포 담당자 확인 필요)