### PR TITLE
[BE] fix: CORS 설정에 새 도메인 추가

### DIFF
--- a/backend/src/main/java/com/devmatch/backend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/devmatch/backend/global/security/SecurityConfig.java
@@ -91,7 +91,12 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
 
     // 허용할 오리진 설정
-    configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://nbe-6-8-2-team08-vaug.vercel.app"));
+    configuration.setAllowedOrigins(List.of(
+        "http://localhost:3000", 
+        "https://nbe-6-8-2-team08-vaug.vercel.app",
+        "https://www.devmatch.store",
+        "https://devmatch.store"
+    ));
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
 
     // 자격 증명 허용 설정


### PR DESCRIPTION
## 🐛 문제
- 새 도메인 www.devmatch.store에서 API 호출 시 CORS 에러 발생

## ✅ 해결
- SecurityConfig CORS 설정에 새 도메인 추가
  - https://www.devmatch.store
  - https://devmatch.store

## 📝 테스트
- 배포 후 www.devmatch.store에서 API 호출 정상 작동 확인 필요